### PR TITLE
feat: Add global SCSS structure and import into React app

### DIFF
--- a/technoproject-theme/src/index.tsx
+++ b/technoproject-theme/src/index.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import CourseList from './components/organisms/CourseList';
 
-// Placeholder for global styles - create this file later
-// import './styles/globals/main.scss';
+// Import global styles
+import './styles/globals/main.scss';
 
 const container = document.getElementById('root');
 

--- a/technoproject-theme/src/styles/globals/main.scss
+++ b/technoproject-theme/src/styles/globals/main.scss
@@ -1,0 +1,88 @@
+// technoproject-theme/src/styles/globals/main.scss
+
+// 1. Settings - Global variables, site-wide settings.
+@import '../settings/variables';
+
+// 2. Tools - Globally used mixins and functions.
+@import '../tools/mixins';
+
+// 3. Generic - Reset and/or normalize styles, box-sizing definition.
+// Example for a simple reset (consider using a more comprehensive one like normalize.css or a modern reset)
+/* Simple Reset */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  // Smooth scrolling for anchor links
+  scroll-behavior: smooth;
+  // Better fluid typography and spacing
+  font-size: 100%; // Usually 16px by default, but can be user-defined
+}
+
+body {
+  font-family: $font-family-primary;
+  font-size: $font-size-base;
+  line-height: 1.6;
+  color: $color-gray-700; // Default text color
+  background-color: $color-gray-50; // Default background color
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+// 4. Elements - Styling for bare HTML elements (e.g., h1, A, etc.).
+h1, h2, h3, h4, h5, h6 {
+  font-family: $font-family-heading;
+  color: $color-gray-900; // Default heading color
+  margin-bottom: $spacing-3;
+  line-height: 1.3;
+}
+
+h1 { font-size: $font-size-4xl; }
+h2 { font-size: $font-size-3xl; }
+h3 { font-size: $font-size-2xl; }
+h4 { font-size: $font-size-xl; }
+h5 { font-size: $font-size-lg; }
+h6 { font-size: $font-size-base; }
+
+p {
+  margin-bottom: $spacing-4;
+}
+
+a {
+  color: $color-secondary; // Using secondary color for links
+  text-decoration: none;
+  transition: color $transition-fast;
+
+  &:hover,
+  &:focus {
+    color: darken($color-secondary, 10%);
+    text-decoration: underline;
+  }
+}
+
+img, video {
+  max-width: 100%;
+  height: auto;
+  display: block; // Remove bottom space under images
+}
+
+// 5. Objects - Unstyled design patterns, e.g., media object, grid system (if not using CSS Grid directly in components).
+// .o-container { ... }
+// .o-grid { ... }
+
+// 6. Components - Specific UI components. (These will mostly be in their own .module.scss files)
+// However, you might have some global component overrides or base styles here.
+
+// 7. Utilities - Utility and helper classes.
+// .u-text-center { text-align: center !important; }
+// .u-visually-hidden { @include visually-hidden; } // Example of using a mixin for a utility class
+
+// Example of using a utility class with the visually-hidden mixin
+.sr-only { // Screen-reader only, alias for visually-hidden
+     @include visually-hidden;
+}

--- a/technoproject-theme/src/styles/settings/_variables.scss
+++ b/technoproject-theme/src/styles/settings/_variables.scss
@@ -1,0 +1,97 @@
+// technoproject-theme/src/styles/settings/_variables.scss
+
+// Colores basados en la identidad visual de Technoproject
+$color-primary: #1a2332; // Azul marino profundo del logo
+$color-secondary: #00d4ff; // Cyan/turquesa del logo
+$color-accent: #ffd700; // Dorado para acentos premium
+$color-success: #28a745;
+$color-warning: #ffc107;
+$color-error: #dc3545;
+$color-info: #17a2b8;
+
+// Paleta de grises sofisticados
+$color-gray-50: #f8fafc;
+$color-gray-100: #f1f5f9;
+$color-gray-200: #e2e8f0;
+$color-gray-300: #cbd5e1;
+$color-gray-400: #94a3b8;
+$color-gray-500: #64748b;
+$color-gray-600: #475569;
+$color-gray-700: #334155;
+$color-gray-800: #1e293b;
+$color-gray-900: #0f172a;
+
+// Tipografía profesional
+$font-family-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+$font-family-heading: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+$font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+// Escala tipográfica modular
+$font-size-xs: 0.75rem;    // 12px
+$font-size-sm: 0.875rem;   // 14px
+$font-size-base: 1rem;     // 16px
+$font-size-lg: 1.125rem;   // 18px
+$font-size-xl: 1.25rem;    // 20px
+$font-size-2xl: 1.5rem;    // 24px
+$font-size-3xl: 1.875rem;  // 30px
+$font-size-4xl: 2.25rem;   // 36px
+$font-size-5xl: 3rem;      // 48px
+
+// Espaciado consistente basado en múltiplos de 8px
+$spacing-unit: 0.25rem; // 4px, base unit for spacing
+$spacing-1: $spacing-unit;      // 4px
+$spacing-2: $spacing-unit * 2;  // 8px
+$spacing-3: $spacing-unit * 3;  // 12px
+$spacing-4: $spacing-unit * 4;  // 16px
+$spacing-5: $spacing-unit * 5;  // 20px
+$spacing-6: $spacing-unit * 6;  // 24px
+$spacing-8: $spacing-unit * 8;  // 32px
+$spacing-10: $spacing-unit * 10; // 40px
+$spacing-12: $spacing-unit * 12; // 48px
+$spacing-16: $spacing-unit * 16; // 64px
+$spacing-20: $spacing-unit * 20; // 80px
+
+// Breakpoints responsive
+$breakpoint-sm: 640px;
+$breakpoint-md: 768px;
+$breakpoint-lg: 1024px;
+$breakpoint-xl: 1280px;
+$breakpoint-2xl: 1536px;
+
+// Sombras y elevaciones
+$shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+$shadow-base: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+$shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+$shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+$shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+$shadow-inset: inset 0 2px 4px 0 rgba(0,0,0,0.06);
+
+
+// Transiciones suaves
+$transition-fast: 150ms ease-in-out;
+$transition-base: 250ms ease-in-out;
+$transition-slow: 350ms ease-in-out;
+
+// Border radius
+$radius-sm: 0.25rem;
+$radius-base: 0.375rem;
+$radius-md: 0.5rem;
+$radius-lg: 0.75rem;
+$radius-xl: 1rem;
+$radius-full: 9999px;
+
+// Z-indexes
+$z-index-dropdown: 1000;
+$z-index-sticky: 1020;
+$z-index-fixed: 1030;
+$z-index-modal-backdrop: 1040;
+$z-index-modal: 1050;
+$z-index-popover: 1060;
+$z-index-tooltip: 1070;
+
+// Container widths
+$container-max-width-sm: 540px;
+$container-max-width-md: 720px;
+$container-max-width-lg: 960px;
+$container-max-width-xl: 1140px;
+$container-max-width-xxl: 1320px;

--- a/technoproject-theme/src/styles/tools/_mixins.scss
+++ b/technoproject-theme/src/styles/tools/_mixins.scss
@@ -1,0 +1,133 @@
+// technoproject-theme/src/styles/tools/_mixins.scss
+@import '../settings/variables'; // Import variables to be used in mixins
+
+// Responsive breakpoint manager
+// Example: @include respond-to(md) { ...styles... }
+// @mixin respond-to($breakpoint) {
+//   @if map-has-key($breakpoints, $breakpoint) {
+//     @media (min-width: map-get($breakpoints, $breakpoint)) {
+//       @content;
+//     }
+//   } @else {
+//     @warn "Breakpoint `#{$breakpoint}` not found in $breakpoints map. Available breakpoints: #{map-keys($breakpoints)}";
+//   }
+// }
+
+// Helper map for respond-to, assuming $breakpoints are defined in _variables.scss
+// If not, define them here or ensure they are available.
+// For this example, I'll use the direct variable names from _variables.scss
+// A map is cleaner if you have many breakpoints.
+
+// Using direct variables (ensure _variables.scss is imported before this file in main.scss)
+@mixin respond-to-sm {
+  @media (min-width: $breakpoint-sm) { @content; }
+}
+@mixin respond-to-md {
+  @media (min-width: $breakpoint-md) { @content; }
+}
+@mixin respond-to-lg {
+  @media (min-width: $breakpoint-lg) { @content; }
+}
+@mixin respond-to-xl {
+  @media (min-width: $breakpoint-xl) { @content; }
+}
+@mixin respond-to-2xl {
+  @media (min-width: $breakpoint-2xl) { @content; }
+}
+
+// Button variant generator (as per document)
+// Example: @include button-variant($color-primary, white);
+@mixin button-variant($bg-color, $text-color: white, $border-color: $bg-color, $hover-darken-percent: 10%) {
+  background-color: $bg-color;
+  color: $text-color;
+  border: 1px solid $border-color;
+  transition: all $transition-base;
+
+  &:hover:not(:disabled):not(.loading) {
+    background-color: darken($bg-color, $hover-darken-percent);
+    border-color: darken($border-color, $hover-darken-percent);
+    transform: translateY(-1px); // Slight lift effect
+    box-shadow: $shadow-md;     // Add some shadow
+  }
+
+  &:active:not(:disabled):not(.loading) {
+    transform: translateY(0);
+    box-shadow: $shadow-sm;
+  }
+
+  &:disabled,
+  &.loading { // Assuming a .loading class can be added to the button
+    opacity: 0.65; // Standard disabled opacity
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+  }
+}
+
+// Card elevation (as per document)
+// Example: @include card-elevation(3);
+@mixin card-elevation($level: 1) {
+  @if $level == 1 {
+    box-shadow: $shadow-sm;
+  } @else if $level == 2 {
+    box-shadow: $shadow-base;
+  } @else if $level == 3 {
+    box-shadow: $shadow-md;
+  } @else if $level == 4 {
+    box-shadow: $shadow-lg;
+  } @else if $level == 5 {
+    box-shadow: $shadow-xl;
+  } @else {
+    box-shadow: none;
+  }
+  transition: box-shadow $transition-base, transform $transition-base; // Added transform for hover effects
+}
+
+// Focus ring (as per document)
+// Example: &:focus-visible { @include focus-ring; }
+@mixin focus-ring($color: $color-secondary, $width: 3px, $offset: 2px) {
+  outline: none;
+  // Using box-shadow for a more flexible focus ring that follows border-radius
+  // box-shadow: 0 0 0 $offset $color-white, 0 0 0 ($offset + $width) rgba($color, 0.5); // Example with outline and inline shadow
+  box-shadow: 0 0 0 $width rgba($color, 0.4);
+}
+
+// Visually hidden class for accessibility (screen reader only content)
+@mixin visually-hidden {
+     position: absolute;
+     width: 1px;
+     height: 1px;
+     padding: 0;
+     margin: -1px;
+     overflow: hidden;
+     clip: rect(0, 0, 0, 0);
+     white-space: nowrap; /* added */
+     border: 0;
+ }
+
+ // Clearfix for float containment
+ @mixin clearfix {
+     &::after {
+         content: "";
+         display: table;
+         clear: both;
+     }
+ }
+
+ // Text truncation with ellipsis for single line
+ // Example: @include truncate;
+ @mixin truncate {
+     overflow: hidden;
+     text-overflow: ellipsis;
+     white-space: nowrap;
+ }
+
+ // Multi-line text truncation (requires display: -webkit-box)
+ // Example: @include truncate-lines(3);
+ @mixin truncate-lines($lines: 2) {
+     display: -webkit-box;
+     -webkit-line-clamp: $lines;
+     -webkit-box-orient: vertical;
+     overflow: hidden;
+     text-overflow: ellipsis;
+ }


### PR DESCRIPTION
I've implemented the foundational global SCSS styling infrastructure:

1.  **_variables.scss:** I created this in `src/styles/settings/` with design tokens (colors, typography, spacing, breakpoints, etc.) as per your architecture document (section 5.2).
2.  **_mixins.scss:** I created this in `src/styles/tools/` with reusable SCSS mixins (responsive helpers, button variants, card elevation, focus rings, etc.) as per your architecture document (section 5.2). This file imports `_variables.scss`.
3.  **main.scss:** I created this in `src/styles/globals/` as the main global SCSS entry point. It imports `_variables.scss` and `_mixins.scss`, and includes basic CSS resets and base HTML element styling (html, body, headings, links).
4.  **src/index.tsx Updated:** I modified this to import `src/styles/globals/main.scss` to apply these global styles, variables, and mixins to the entire React application.

This should resolve issues related to components not finding global SASS variables or mixins during compilation.