### PR TITLE
I've made some adjustments to the course custom post type to help wit…

### DIFF
--- a/technoproject-theme/includes/custom-post-types/course-cpt.php
+++ b/technoproject-theme/includes/custom-post-types/course-cpt.php
@@ -47,7 +47,7 @@ function technoproject_register_course_post_type() {
         'description'           => __( 'Post Type para Cursos de Technoproject', 'technoproject' ),
         'labels'                => $labels,
         'supports'              => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'excerpt', 'author', 'revisions' ), // Added excerpt, author, revisions from common practice
-        'taxonomies'            => array( /* 'course_category', 'skill_tag' - will be registered separately */ ),
+        'taxonomies'            => array( 'course_category', 'skill_tag' ),
         'hierarchical'          => false,
         'public'                => true,
         'show_ui'               => true,
@@ -60,8 +60,8 @@ function technoproject_register_course_post_type() {
         'has_archive'           => 'cursos', // As per document 'rewrite' => array('slug' => 'cursos')
         'exclude_from_search'   => false,
         'publicly_queryable'    => true,
-        'capability_type'       => 'course', // As per document
-        'map_meta_cap'          => true,     // As per document
+        'capability_type'       => 'post', // Changed for diagnostics
+        // 'map_meta_cap'          => true, // Less critical if capability_type is 'post'
         'show_in_rest'          => true,     // As per document
         'rest_base'             => 'courses',// As per document
         'rest_controller_class' => 'WP_REST_Posts_Controller', // As per document


### PR DESCRIPTION
…h visibility diagnostics.

In the file `technoproject-theme/includes/custom-post-types/course-cpt.php`, I've:
- Explicitly associated the 'course_category' and 'skill_tag' taxonomies within the custom post type arguments.
- Temporarily changed the 'capability_type' from 'course' to 'post' for diagnostic purposes. This will help us determine if capability-related issues are preventing the custom post type's user interface (like the "Add New Course" menu) from appearing.
- Commented out 'map_meta_cap' as it's less relevant when the 'capability_type' is set to 'post'.

The goal of these changes is to make the "Course" custom post type admin menus visible for you.